### PR TITLE
Generic: avoid conflict between Good Bot and Hi Bot commands

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -145,6 +145,7 @@
 			<group>
 				<word>bad</word>
 				<word>evening</word>
+				<word>morning</word>
 			</group>
 		</unwantedwords>
 		<responses forward="false">


### PR DESCRIPTION
Message "good morning Botimuz" incorrectly triggers the "Good Bot"
command instead of the "Hi Bot" command.  To fix this conflict, add
missing unwanted word "morning" to the "Good Bot" command, corresponding
to "good morning" in the "Hi Bot" command, as was already done for "good
evening".