### PR TITLE
Examples: Fix chance in description of "weighting" attribute

### DIFF
--- a/Example Command.xml
+++ b/Example Command.xml
@@ -103,7 +103,7 @@ Required -->
 			Attribute "weighting": Defines the chance of response being used when using random responses 
 			Optional: Default = 1
 			Values: 0-255
-			Example: If there are 3 responses all with default weighting they have a 1/3 chance off being picked. If one response has a weighting of 3 then it instead has a 3/6 chance-->
+			Example: If there are 3 responses all with default weighting they have a 1/3 chance off being picked. If one response has a weighting of 3 then it instead has a 3/5 chance-->
 
 			<response data0="currentTime" data1="twitchTitle">The time is: [0] and the title is [1]</response>
 			<!-- Attribute "data0": Defines a variety of possible data responses for the [0] text


### PR DESCRIPTION
When there are three responses, and two have the default weighting of 1
and one of them has a weighting of 3, then it instead has a chance of
3/(1+1+3) = 3/5.