### PR TITLE
Online: update tier 1 emotes in "Timed Emote Spam" command

### DIFF
--- a/Commands/Online.xml
+++ b/Commands/Online.xml
@@ -23,6 +23,8 @@
 			<response>joshBarksAtKitty</response>
 			<response>joshKittylina</response>
 			<response>joshCJPlz</response>
+			<response>joshOMG</response>
+			<response>joshS</response>
 			<response>botimu2Bot</response>
 		</responses>
 		<dataTrigger type="timer">1800-3600</dataTrigger>

--- a/Commands/Online.xml
+++ b/Commands/Online.xml
@@ -16,8 +16,6 @@
 			<response>joshIsFine</response>
 			<response>joshCoolStory</response>
 			<response>joshGlod</response>
-			<response>joshREE</response>
-			<response>joshEEE</response>
 			<response weighting="2">joshDosh</response>
 			<response>joshFinking</response>
 			<response>joshBarksAtKitty</response>


### PR DESCRIPTION
Update the list of Tier 1 Joshimuz emotes which are used in the "Timed Emote Spam" command in the command collection "Online".