### PR TITLE
ESA: say that ESA Winter 2021 is live

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -372,7 +372,7 @@
 			</group>
 		</unwantedwords>
 		<responses>
-			<response>ESA Winter starts 12 February 2021 https://esamarathon.com/schedule</response>
+			<response>ESA Winter is live right now at https://www.twitch.tv/esamarathon. Schedule: https://esamarathon.com/schedule</response>
 		</responses>
 	</command>
 	<command>


### PR DESCRIPTION
ESA Winter 2021 has started, so saying "starts 12 February 2021" no
longer makes sense.

----

This pull request is a replacement for #6.