### PR TITLE
VCS: add out of bounds command

### DIFF
--- a/Commands/VCS.xml
+++ b/Commands/VCS.xml
@@ -244,4 +244,22 @@
 			<response>Josh starts side missions for "OnMission"-variable manipulation, the basis behind duping. For more info about duping, please read: https://faq.joshimuz.com/#what-is-duping-1</response>
 		</responses>
 	</command>
+	<command>
+		<name>Why out of bounds</name>
+		<requiredwords>
+			<group>
+				<word>botimuz</word>
+				<word wholeword="true">bot</word>
+				<word>why</word>
+			</group>
+			<group>
+				<word>out of bounds</word>
+				<word wholeword="true">oob</word>
+			</group>
+		</requiredwords>
+		<maxWords>15</maxWords>
+		<responses>
+			<response>Josh goes out of bounds to flip all vehicles in all axes (we don't yet know why it happens). This blows up the vans in WUTN, which passes the missions.</response>
+		</responses>
+	</command>
 </commands>


### PR DESCRIPTION
A command about going out of bound in GTA Vice City Stories to flip all vehicles has been added.