### PR TITLE
Generic: ignore "bingo" for the "What time" command

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -119,6 +119,7 @@
 				<word wholeword="true">it's</word>
 				<word>does</word>
 				<word>it is</word>
+				<word>bingo</word>
 			</group>
 		</unwantedwords>
 		<responses>


### PR DESCRIPTION
From today's chat:
> 21:32 Momo_Ouali2001: Josh what was the end time for the bingo run earlier
> 21:32 Botimuz: @Momo_Ouali2001 It's currently 20:32 in the UK