### PR TITLE
Make MC Bingo CC independent, fix command triggers

### DIFF
--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -255,7 +255,7 @@
       <name>Generic</name>
       <name>Online</name>
       <name>MinecraftBingo</name>
-      <name>Minecraft</name>
+      <!--<name>Minecraft</name>-->
     </commandlists>
     <streamstatus>online</streamstatus>
   </commandcollection>

--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -591,6 +591,11 @@
 				<word>bingo</word>
 			</group>
 		</requiredwords>
+		<unwantedwords>
+			<group>
+				<word wholeword="true">me</word>
+			</group>
+		</unwantedwords>
 		<responses>
 			<response>Josh is working on a new Minecraft Bingo version. He will probably playtest it from time to time. You can play MCBingo yourself on https://minecraftbingo.com (click the v3 button for the dev version)</response>
 		</responses>

--- a/Commands/MinecraftBingo.xml
+++ b/Commands/MinecraftBingo.xml
@@ -31,6 +31,12 @@
             <group>
                 <word>color</word>
                 <word>colour</word>
+                <word>blue</word>
+                <word>yellow</word>
+                <word>brown</word>
+                <word>red</word>
+                <word>pink</word>
+                <word>green</word>
             </group>
             <group>
                 <word>sheet</word>

--- a/Commands/MinecraftBingo.xml
+++ b/Commands/MinecraftBingo.xml
@@ -1,5 +1,33 @@
 <commands version="1">
     <command>
+		<name>Left Handed</name>
+		<requiredwords>
+			<group>
+				<word>why</word>
+				<word>are you</word>
+				<word>are u</word>
+				<word>?</word>
+				<word>botimuz</word>
+				<word wholeword="true">bot</word>
+			</group>
+			<group>
+				<word>left</word>
+			</group>
+			<group>
+				<word>hand</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh is ambidextrous, however he plays Minecraft Left Handed because it makes Left Click; Left Hand and Right Click; Right Hand (how can anyone play otherwise, baffles him)</response>
+		</responses>
+		<unwantedwords>
+			<group>
+				<word wholeword="true">im</word>
+				<word>i'm</word>
+			</group>
+		</unwantedwords>
+	</command>
+    <command>
         <name>Can I Play?</name>
         <requiredwords>
             <group>


### PR DESCRIPTION
- Fixed false `MC Bingo` command trigger in Generic
- Added colours to the `Colours meaning` command in MC Bingo
- Made the `MC Bingo` command collection independent by adding the lefthanded command and removing the `Minecraft` CC from the collection.