### PR TITLE
Split command lists into Minecraft, MCBingo and MCServer

### DIFF
--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -255,8 +255,8 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>Minecraft</name>
       <name>MinecraftBingo</name>
-      <!--<name>Minecraft</name>-->
     </commandlists>
     <streamstatus>online</streamstatus>
   </commandcollection>

--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -226,7 +226,7 @@
   </commandcollection>
 
   <commandcollection>
-    <name>Minecraft</name>
+    <name>MinecraftServer</name>
     <channelname>Joshimuz</channelname>
     <unwantedtitlewords>
       <group>
@@ -238,6 +238,7 @@
       <name>Generic</name>
       <name>Online</name>
       <name>Minecraft</name>
+      <name>MinecraftServer</name>
     </commandlists>
     <streamstatus>online</streamstatus>
   </commandcollection>

--- a/Commands/Minecraft.xml
+++ b/Commands/Minecraft.xml
@@ -28,51 +28,6 @@
 		</unwantedwords>
 	</command>
 	<command>
-		<name>Can I Join?</name>
-		<requiredwords>
-			<group>
-				<word>what</word>
-				<word>which</word>
-				<word>!server</word>
-				<word>is this</word>
-				<word wholeword="true">can</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>join</word>
-				<word wholeword="true">server</word>
-				<word>play with</word>
-				<word>connect</word>
-				<word>realms</word>
-				<word>!server</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh is playing on a Java server with his speedfriends. He was considering making a subs only server at one point, however he can't be bothered to maintain/moderate such a server.</response>
-		</responses>
-	</command>
-	<command>
-		<name>Modded?</name>
-		<requiredwords>
-			<group>
-				<word>what</word>
-				<word>any</word>
-				<word>which</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>modded</word>
-				<word>mods</word>
-				<word>vanilla</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh is playing Vanilla 1.16 on his server. He is however using his datapack (Vanilla with Flake) to make Vanilla a little less dumb.</response>
-		</responses>
-	</command>
-		<command>
 		<name>OpenGL Error</name>
 		<requiredwords>
 			<group>

--- a/Commands/MinecraftBingo.xml
+++ b/Commands/MinecraftBingo.xml
@@ -1,33 +1,5 @@
 <commands version="1">
     <command>
-		<name>Left Handed</name>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>are you</word>
-				<word>are u</word>
-				<word>?</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>left</word>
-			</group>
-			<group>
-				<word>hand</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh is ambidextrous, however he plays Minecraft Left Handed because it makes Left Click; Left Hand and Right Click; Right Hand (how can anyone play otherwise, baffles him)</response>
-		</responses>
-		<unwantedwords>
-			<group>
-				<word wholeword="true">im</word>
-				<word>i'm</word>
-			</group>
-		</unwantedwords>
-	</command>
-    <command>
         <name>Can I Play?</name>
         <requiredwords>
             <group>

--- a/Commands/MinecraftServer.xml
+++ b/Commands/MinecraftServer.xml
@@ -1,0 +1,47 @@
+<commands version="1">
+    <command>
+		<name>Can I Join?</name>
+		<requiredwords>
+			<group>
+				<word>what</word>
+				<word>which</word>
+				<word>!server</word>
+				<word>is this</word>
+				<word wholeword="true">can</word>
+				<word>botimuz</word>
+				<word wholeword="true">bot</word>
+			</group>
+			<group>
+				<word>join</word>
+				<word wholeword="true">server</word>
+				<word>play with</word>
+				<word>connect</word>
+				<word>realms</word>
+				<word>!server</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh is playing on a Java server with his speedfriends. He was considering making a subs only server at one point, however he can't be bothered to maintain/moderate such a server.</response>
+		</responses>
+	</command>
+	<command>
+		<name>Modded?</name>
+		<requiredwords>
+			<group>
+				<word>what</word>
+				<word>any</word>
+				<word>which</word>
+				<word>botimuz</word>
+				<word wholeword="true">bot</word>
+			</group>
+			<group>
+				<word>modded</word>
+				<word>mods</word>
+				<word>vanilla</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh is playing Vanilla 1.16 on his server. He is however using his datapack (Vanilla with Flake) to make Vanilla a little less dumb.</response>
+		</responses>
+	</command>
+</commands>


### PR DESCRIPTION
This change is so we can easily add commands for `Bingo`, `Server `and `Minecraft` itself. `Bingo` and `Server` will use the `Minecraft` command list.
Also, I was mistakenly referring to command lists as `CC` (command collection), therefore replace anything relating to `CC` with `CL.`