### PR TITLE
Add the em dash after MCBingo link

### DIFF
--- a/Commands/MinecraftBingo.xml
+++ b/Commands/MinecraftBingo.xml
@@ -121,7 +121,7 @@
             </group>
         </unwantedwords>
         <responses>
-            <response>This is not an ordinary speedrun! Josh is playing https://minecraftbingo.com The goal is to complete one row, column or diagonal line of tasks.</response>
+            <response>This is not an ordinary speedrun! Josh is playing https://minecraftbingo.com — the goal is to complete one row, column or diagonal line of tasks.</response>
         </responses>
     </command>
     <command>
@@ -151,7 +151,7 @@
             </group>
         </unwantedwords>
 		<responses>
-			<response>Josh is playing https://minecraftbingo.com The goal is to complete one row, column or diagonal line of tasks.</response>
+			<response>Josh is playing https://minecraftbingo.com — the goal is to complete one row, column or diagonal line of tasks.</response>
 		</responses>
     </command>
 </commands>


### PR DESCRIPTION
Addressing https://github.com/Joshimuz/BotimuzCommands/pull/18#issuecomment-792269202 once and for all to add an em dash after the link to remove necessity for punctuation right after the link.