### PR TITLE
iRacing: VR chat: check forms of "see" more carefully

### DIFF
--- a/Commands/iRacing.xml
+++ b/Commands/iRacing.xml
@@ -143,7 +143,9 @@
 				<word wholeword="true">you</word>
 			</group>
 			<group>
-				<word>see</word>
+				<word wholeword="true">see</word>
+				<word wholeword="true">sees</word>
+				<word>seeing</word>
 				<word>read</word>
 				<word>reading</word>
 			</group>


### PR DESCRIPTION
Botimuz gets confused by "see" in "seem"/"seems", e.g. answering to

> Sventor: it seems every person writing in chat without a sub
> badge is being targeted monkaS

and

> yaoi69: seems like chat is helping to improve josh his bot