### PR TITLE
VCS: fix typo in "When LCS" command

### DIFF
--- a/Commands/VCS.xml
+++ b/Commands/VCS.xml
@@ -228,7 +228,7 @@
 			</group>
 		</requiredwords>
 		<responses>
-			<response>Josh never played LCS on PSP when it released, he only ever played it when it came on out Mobile, and thought it was "alright". He's never done runs, and doesn't plan to because he can run this instead.</response>
+			<response>Josh never played LCS on PSP when it released, he only ever played it when it came out on Mobile, and thought it was "alright". He's never done runs, and doesn't plan to because he can run this instead.</response>
 		</responses>
 	</command>
 	<command>


### PR DESCRIPTION
Words in "it came out on Mobile" were in wrong order.