### PR TITLE
Generic: react to "sitrep" for !title command

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -292,6 +292,7 @@
 			</group>
 			<group>
 				<word>title</word>
+				<word>sitrep</word>
 			</group>
 		</requiredwords>
 		<responses data0="twitchtitle">


### PR DESCRIPTION
When sitrep is mentioned on screen, people keep asking for it.  Since
usually the title includes the link to the sitrep clip, let's just react
to the word "sitrep" as well.  Sitrep is only actual for iRacing
streams, but it won't hurt for other streams.