### PR TITLE
Fix "Why no Radio" command 

### DIFF
--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -59,6 +59,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>SA</name>
       <name>ChaosMod</name>
     </commandlists>
@@ -79,6 +80,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>SA</name>
       <name>SANoAJS</name>
     </commandlists>
@@ -99,6 +101,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>SA</name>
       <name>SANMG</name>
     </commandlists>
@@ -127,6 +130,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>SAAny</name>
     </commandlists>
     <speedruncategory>Any%</speedruncategory>
@@ -151,6 +155,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>VCS</name>
     </commandlists>
     <speedruncategory>Any%</speedruncategory>
@@ -171,6 +176,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>VCS</name>
     </commandlists>
     <speedruncategory>No Major Glitches</speedruncategory>
@@ -195,6 +201,7 @@
     <commandlists>
       <name>Generic</name>
       <name>Online</name>
+      <name>GTA</name>
       <name>MTA</name>
     </commandlists>
     <streamstatus>online</streamstatus>

--- a/Commands/GTA.xml
+++ b/Commands/GTA.xml
@@ -1,0 +1,30 @@
+<commands version="1">
+	<command>
+		<name>Why no Radio</name>
+		<maxWords>10</maxWords>
+		<requiredwords>
+			<group>
+				<word>why</word>
+				<word>where</word>
+				<word>?</word>
+				<word>botimuz</word>
+				<word wholeword="true">bot</word>
+			</group>
+			<group>
+				<word>no</word>
+				<word>don't</word>
+				<word>dont</word>
+				<word>disable</word>
+				<word>where</word>
+			</group>
+			<group>
+				<word>radio</word>
+				<word>music</word>
+				<word>tune</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music. Also https://twitter.com/Joshimuz/status/1270988855508959232</response>
+		</responses>
+	</command>
+</commands>

--- a/Commands/GTA.xml
+++ b/Commands/GTA.xml
@@ -6,16 +6,19 @@
 			<group>
 				<word>why</word>
 				<word>where</word>
-				<word>?</word>
 				<word>botimuz</word>
 				<word wholeword="true">bot</word>
 			</group>
 			<group>
-				<word>no</word>
+				<word wholeword="true">no</word>
 				<word>don't</word>
 				<word>dont</word>
+				<word wholeword="true">is</word>
+				<word>isn't</word>
+				<word>isnt</word>
+				<word>doesn't</word>
+				<word>doesnt</word>
 				<word>disable</word>
-				<word>where</word>
 			</group>
 			<group>
 				<word>radio</word>
@@ -24,7 +27,7 @@
 			</group>
 		</requiredwords>
 		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music. Also https://twitter.com/Joshimuz/status/1270988855508959232</response>
+			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so radio is turned off and he mutes the game when there is music. Also https://twitter.com/Joshimuz/status/1270988855508959232</response>
 		</responses>
 	</command>
 </commands>

--- a/Commands/MTA.xml
+++ b/Commands/MTA.xml
@@ -1,33 +1,5 @@
 <commands>
 	<command>
-		<name>Why no Radio</name>
-		<maxlength>10</maxlength>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>where</word>
-				<word>?</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>no</word>
-				<word>don't</word>
-				<word>dont</word>
-				<word>disable</word>
-			</group>
-			<group>
-				<word>radio</word>
-				<word>music</word>
-				<word>tune</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music.</response>
-		</responses>
-	</command>
-	
-	<command>
 		<name>Version</name>
 		<maxlength>15</maxlength>
 		<requiredwords>

--- a/Commands/SA.xml
+++ b/Commands/SA.xml
@@ -1,33 +1,5 @@
 ﻿<commands version="1">
 	<command>
-		<name>Why no Radio</name>
-		<maxWords>10</maxWords>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>where</word>
-				<word>?</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>no</word>
-				<word>don't</word>
-				<word>dont</word>
-				<word>disable</word>
-				<word>where</word>
-			</group>
-			<group>
-				<word>radio</word>
-				<word>music</word>
-				<word>tune</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music. Also https://twitter.com/Joshimuz/status/1270988855508959232</response>
-		</responses>
-	</command>
-	<command>
 		<name>Camera Flick</name>
 		<maxWords>15</maxWords>
 		<requiredwords>

--- a/Commands/SAAny.xml
+++ b/Commands/SAAny.xml
@@ -1,31 +1,5 @@
 ﻿<commands version="1">
 	<command>
-		<name>Why no Radio</name>
-		<maxWords>10</maxWords>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>where</word>
-				<word>?</word>
-			</group>
-			<group>
-				<word>no</word>
-				<word>don't</word>
-				<word>dont</word>
-				<word>disable</word>
-				<word>where</word>
-			</group>
-			<group>
-				<word>radio</word>
-				<word>music</word>
-				<word>tunes</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music.</response>
-		</responses>
-	</command>
-	<command>
 		<name>Version</name>
 		<maxWords>15</maxWords>
 		<requiredwords>

--- a/Commands/SARando.xml
+++ b/Commands/SARando.xml
@@ -1,34 +1,5 @@
 <commands>
 	<command>
-		<name>Why no Radio</name>
-		<maxlength>10</maxlength>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>where</word>
-				<word>?</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>no</word>
-				<word>don't</word>
-				<word>dont</word>
-				<word>disable</word>
-				<word>where</word>
-			</group>
-			<group>
-				<word>radio</word>
-				<word>music</word>
-				<word>tune</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so he mutes the game when there is music.</response>
-		</responses>
-	</command>
-	
-	<command>
 		<name>Camera Flick</name>
 		<maxlength>15</maxlength>
 		<requiredwords>

--- a/Commands/VCS.xml
+++ b/Commands/VCS.xml
@@ -1,32 +1,5 @@
 ﻿<commands version="1">
 	<command>
-		<name>Why no Radio</name>
-		<requiredwords>
-			<group>
-				<word>why</word>
-				<word>where</word>
-				<word>?</word>
-				<word>botimuz</word>
-				<word wholeword="true">bot</word>
-			</group>
-			<group>
-				<word>no</word>
-				<word>don't</word>
-				<word>dont</word>
-				<word>disable</word>
-				<word>where</word>
-			</group>
-			<group>
-				<word>radio</word>
-				<word>music</word>
-				<word>tunes</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Josh wants to avoid all copyright issues for all time, here and Youtube, so the radio is turned off.</response>
-		</responses>
-	</command>
-	<command>
 		<name>Console</name>
 		<maxWords>10</maxWords>
 		<requiredwords>


### PR DESCRIPTION
Command  "Why no Radio" has been moved into new file `GTA.xml`. Its `<requiredwords>` block has been fixed and improved.

The word groups were updated so that first group is only "asking" words, second group is only verbs (plus "no"), and third group is only synonyms for "radio".