### PR TITLE
More JDQ III command updates

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -778,6 +778,33 @@
 		</responses>
 	</command>
 	<command>
+		<name>JDQ schedule</name>
+		<maxWords>15</maxWords>
+		<requiredwords>
+			<group>
+				<word wholeword="true">bot</word>
+				<word>botimuz</word>
+			</group>
+			<group>
+				<word>schedule</word>
+			</group>
+		</requiredwords>
+		<unwantedwords>
+			<group>
+				<word>watch</word>
+				<word>saw</word>
+				<word>version</word>
+				<word>wants</word>
+				<word>played</word>
+				<word>playing</word>
+				<word wholeword="true">esa</word>
+			</group>
+		</unwantedwords>
+		<responses>
+			<response>Josh Done Quick III schedule: https://horaro.org/jdq/21 Details: https://pastebin.com/eywfvCiT</response>
+		</responses>
+	</command>
+	<command>
 		<name>GTA trilogy remaster/remake</name>
 		<maxWords>15</maxWords>
 		<requiredwords>

--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -809,6 +809,19 @@
 		</responses>
 	</command>
 	<command>
+		<name>JDQ !schedule</name>
+		<maxWords>3</maxWords>
+		<requiredwords>
+			<group>
+				<word>!schedule</word>
+				<word>!pastebin</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh Done Quick III schedule: https://horaro.org/jdq/21 Details: https://pastebin.com/eywfvCiT</response>
+		</responses>
+	</command>
+	<command>
 		<name>GTA trilogy remaster/remake</name>
 		<maxWords>15</maxWords>
 		<requiredwords>

--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -755,6 +755,7 @@
 				<word>botimuz</word>
 				<word>schedule</word>
 				<word>link</word>
+				<word>pastebin</word>
 			</group>
 			<group>
 				<word>joshdonequick</word>
@@ -784,9 +785,12 @@
 			<group>
 				<word wholeword="true">bot</word>
 				<word>botimuz</word>
+				<word>link</word>
+				<word>URL</word>
 			</group>
 			<group>
 				<word>schedule</word>
+				<word>pastebin</word>
 			</group>
 		</requiredwords>
 		<unwantedwords>


### PR DESCRIPTION
A second command is needed because first command can't be updated to trigger on "bot schedule". And people already tried triggering Botimuz with "bot schedule" in the first 30 minutes of the stream.