### PR TITLE
JDQ III: add timed command for donation goals

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -828,6 +828,24 @@
 		</responses>
 	</command>
 	<command>
+		<name>JDQ III goals</name>
+		<maxWords>15</maxWords>
+		<requiredwords>
+			<group>
+				<word wholeword="true">bot</word>
+				<word>botimuz</word>
+				<word>donation</word>
+			</group>
+			<group>
+				<word>goal</word>
+			</group>
+		</requiredwords>
+		<timerRange>1800-3600</timerRange>
+		<responses>
+			<response>Josh will be doing Chaos Mod on Sunday to finish JDQ III, but he'll do extra randomisers if we reach goals! £500 = Voice Line. £1000 = Cosmetic. £2000 = Gameplay. £3000 = Experimental. Also if we reach 1000 subs Josh will learn GTA:SA 100%! joshOOO Details: https://pastebin.com/eywfvCiT</response>
+		</responses>
+	</command>
+	<command>
 		<name>GTA trilogy remaster/remake</name>
 		<maxWords>15</maxWords>
 		<requiredwords>


### PR DESCRIPTION
I'm not sure about `<timerRange>1800-3600</timerRange>` syntax because
there no live commands that use it, but it is described this way in
`Example Command.xml`.  The range of 1800 to 3600 seconds is copied from
"Timed Emote Spam" command in `Online.xml`.