### PR TITLE
Generic.xml: fix link in "GTA trilogy remaster/remake"

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -865,7 +865,7 @@
 			</group>
 		</unwantedwords>
 		<responses>
-			<response>Josh's thoughts on GTA trilogy remaster/remake: https://faq.joshimuz.com#what-are-your-thoughts-on-the-rumoured-gta-3d-trilogy-remasterremake</response>
+			<response>Josh's thoughts on GTA trilogy remaster/remake: https://faq.joshimuz.com/#what-are-your-thoughts-on-the-rumoured-gta-3d-trilogy-remasterremake</response>
 		</responses>
 	</command>
 </commands>


### PR DESCRIPTION
Twitch chat renders the anchor part of URL after "#" only when there is
a slash after the ".com".