### PR TITLE
Generic.xml: move merch command from Online.xml

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -892,4 +892,22 @@
 			<response>Josh's thoughts on GTA trilogy remaster/remake: https://faq.joshimuz.com/#what-are-your-thoughts-on-the-rumoured-gta-3d-trilogy-remasterremake</response>
 		</responses>
 	</command>
+	<command>
+		<name>Merch</name>
+		<maxWords>15</maxWords>
+		<requiredwords>
+			<group>
+				<word wholeword="true">bot</word>
+				<word wholeword="true">link</word>
+				<word wholeword="true">where</word>
+			</group>
+			<group>
+				<word>merch</word>
+				<word>shirt</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Show love for your favourite 6328th streamer with my first ever merch! Get your T-Shirt, Mug, Poster, Sticker etc, today! https://merch.joshimuz.com</response>
+		</responses>
+	</command>
 </commands>

--- a/Commands/Online.xml
+++ b/Commands/Online.xml
@@ -33,27 +33,6 @@
 		</responses>
 		<dataTrigger type="timer">1800-3600</dataTrigger>
 	</command>
-
-	<command>
-		<name>Merch Spam</name>
-		<maxWords>15</maxWords>
-		<requiredwords>
-			<group>
-				<word wholeword="true">bot</word>
-				<word wholeword="true">link</word>
-				<word wholeword="true">where</word>
-			</group>
-			<group>
-				<word>merch</word>
-				<word>shirt</word>
-			</group>
-		</requiredwords>
-		<responses>
-			<response>Show love for your favourite 6328th streamer with my first ever merch! Get your T-Shirt, Mug, Poster, Sticker etc, today! https://merch.joshimuz.com</response>
-		</responses>
-		<!-- <dataTrigger type="timer">900-1800</dataTrigger> -->
-	</command>
-
 	<command>
 		<name>Uptime Metric</name>
 		<maxWords>15</maxWords>


### PR DESCRIPTION
Because it was originally with a timer, the merch bot command is in
`Online.xml`, but now it is more appropriate to put it in `Generic.xml`.