### PR TITLE
Pres for 24h race

### DIFF
--- a/Commands/24hRace.xml
+++ b/Commands/24hRace.xml
@@ -12,7 +12,7 @@
 			</group>
 		</requiredwords>
 		<responses>
-			<response>PROLaps is the Dallara P217, LMP2 class car</response>
+			<response>PROLaps is the Lamborghini Huracán GT3 EVO car</response>
 		</responses>
 	</command>
 

--- a/Commands/24hRace.xml
+++ b/Commands/24hRace.xml
@@ -68,7 +68,7 @@
 			</group>
 		</unwantedwords>
 		<responses>
-			<response>From Fastest to Slowest the classes are: Yellow - LMP1, Blue - LMP2, Pink - GTE</response>
+			<response>From Fastest to Slowest the classes are: Yellow - LMP2, Blue - GT3</response>
 		</responses>
 	</command>
 


### PR DESCRIPTION
- **Car:** Updated for upcoming Daytona 24h. 
- **Classes:** Updated. Verified Class colours by random Twitch VODs currently practicing (Yellow & Blue/Cyan)

- **Schedule:** Update needed, when created

- **When race:** Might be one for _iRacing.xml_. Currently four possible Time Slots (see Ref).
"Race starts on Saturday at 12:45 BST, ends at, believe it or not, 12:45 BST"
(Ref: [_iRacing Master Schedule_](https://docs.google.com/spreadsheets/d/1VoOvsitrMyTwXWEn8pdPzJGtbIA3Sxl6uGFh8bRF4Pc/edit#gid=407167173))
