### PR TITLE
Generic.xml: fix response of "Buy viewers ban"

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -985,7 +985,7 @@
 				<word>bot</word>
 			</group>
 		</unwantedWords>
-		<responses data0="messageid" usename="false">
+		<responses data0="chattername" usename="false">
 			<response>/timeout [0] 24h</response>
 		</responses>
 		<cooldown>0</cooldown>


### PR DESCRIPTION
The response was copy-pasted from commands that use /delete to delete
messages (<message deleted> and "Bot is dead").  But /ban and /timeout
need a chattername.  Compare to /ban in Braille ASCII graphic command
and /timeout in Commands/ChaosMod.xml.

Fixes #77.