### PR TITLE
Prevent live/alive overlap

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -612,6 +612,7 @@
 			<group>
 				<word>strat</word>
 				<word>do</word>
+				<word wholeword="true">live</word>
 			</group>
 		</unwantedwords>
 		<responses forward="false" usename="false" data0="timeSince" range0="714235200">

--- a/Commands/Online.xml
+++ b/Commands/Online.xml
@@ -59,6 +59,7 @@
 				<word>click</word>
 				<word>watch</word>
 				<word>sleep</word>
+				<word wholeword="true">alive</word>
 			</group>
 		</unwantedWords>
 		<responses>
@@ -92,6 +93,7 @@
 		<unwantedWords>
 			<group>
 				<word>sleep</word>
+				<word wholeword="true">alive</word>
 			</group>
 		</unwantedWords>
 		<responses>


### PR DESCRIPTION
_"jurasjuras: how long is josh live?"_
-> Gives Alive time

_"jurasjuras: josh live for how long"_
-> Gives Uptime Metric

I have no idea, if the Commits are going to be safe/working fixes, but this overlap should probably be prevented by _unwantedwords_