### PR TITLE
CommandCollections.xml: use regular Offline.xml

### DIFF
--- a/CommandCollections.xml
+++ b/CommandCollections.xml
@@ -357,7 +357,7 @@
     <channelname>Joshimuz</channelname>
     <commandlists>
       <name>Generic</name>
-      <name>OfflineESA</name>
+      <name>Offline</name>
     </commandlists>
     <streamstatus>offline</streamstatus>
   </commandcollection>


### PR DESCRIPTION
ESA Winter 2022 event has ended, so switch from OfflineESA.xml to the
regular Offline.xml.

The response in Offline.xml refers to the schedule page on Twitch.  But
the schedule has been empty for quite a while now.  Not sure where to
poing the viewer instead.  Maybe Twitter?