### PR TITLE
Generic.xml: ESA Summer 2022

### DIFF
--- a/Commands/Generic.xml
+++ b/Commands/Generic.xml
@@ -997,7 +997,7 @@
 			<response>You can watch Joshimuz ESA content here: post-ESA catchup: twitch.tv/videos/1306314141 | joshCoolStory of travel disasters: twitch.tv/videos/1306335184?t=1h15m0s | GTA:SA run: twitch.tv/videos/1300715392 | GTA:VC DE run (comment): twitch.tv/videos/1296861816 | GTA:TBoGT run (comment): twitch.tv/videos/1303124232 | Board games streams: twitch.tv/videos/1296887509 and twitch.tv/videos/1298665510 botimu2Bot</response>
 		</responses>
 	</command> -->
-	<!--<command>
+	<command>
 		<name>ESA when</name>
 		<maxWords>15</maxWords>
 		<requiredwords>
@@ -1023,9 +1023,9 @@
 			</group>
 		</unwantedwords>
 		<responses>
-			<response>Josh is going to ESA Winter to do a GTA:SA run! ESA Winter is 12 to 19 Feb. esamarathon.com/schedule</response>
+			<response>Josh is going to ESA Summer and he'll maybe do a GTA:SA Chaos relay race! ESA Summer is 23 to 30 July. esamarathon.com/ettevent/esa-summer-2022</response>
 		</responses>
-	</command>-->
+	</command>
 	<command>
 		<name>Buy viewers ban</name>
 		<requiredwords>


### PR DESCRIPTION
At the moment, esamarathon.com/schedule still has the Winter schedule,
so a separate URL for just ESA Summer 2022 has to be used.