### PR TITLE
Edited 'Camera Flick' bot command

### DIFF
--- a/Commands/SA.xml
+++ b/Commands/SA.xml
@@ -35,6 +35,7 @@
 				<word wholeword="true">me</word>
 				<word wholeword="true">looked</word>
 				<word>look it</word>
+				<word>stupid</word>
 			</group>
 		</unwantedwords>
 		<responses>


### PR DESCRIPTION
Added "stupid" to the List of unwanted words. This adresses a misfire of this command that happened on stream, since it contains the substring "up"