### PR TITLE
Added command for ESA tighted run arround easter eggs and ryders car

### DIFF
--- a/Commands/Tightened.xml
+++ b/Commands/Tightened.xml
@@ -58,4 +58,28 @@
 			<response>The mod is currently in closed beta, it'll be released "when it's finished". DinosaurBytes is only working on it in his free time.</response>
 		</responses>
 	</command>
+
+	<command>
+		<name>Easter Egg Incentive</name>
+		<requiredwords>
+			<group>
+				<word wholeword="true">don't</word>
+				<word wholeword="true">dont</word>
+				<word wholeword="true">didnt</word>
+				<word wholeword="true">didn't</word>
+			</group>
+			<group>
+				<word wholeword="true">blow</word>
+			</group>
+			<group>
+				<word>ryder</word>
+			</group>
+			<group>
+				<word wholeword="true">car</word>
+			</group>
+		</requiredwords>
+		<responses>
+			<response>Josh's ESA route that he is practising intentionally misses some tricks and skips in order to show them off for an Easter Egg incentive.</response>
+		</responses>
+	</command>
 </commands>


### PR DESCRIPTION
If someone asks in chat why dont you blow up riders car, botimuz can respond saying it's for easter egg incentive